### PR TITLE
Travis continuous logging

### DIFF
--- a/.travis.install.sh
+++ b/.travis.install.sh
@@ -1,6 +1,8 @@
 set -e
 set -v
 
+while true; do echo "INSTALL IS RUNNING" && sleep 5; done&
+
 sudo sh -c 'echo "deb http://packages.ros.org/ros/ubuntu trusty main" > /etc/apt/sources.list.d/ros-latest.list'
 wget http://packages.ros.org/ros.key -O - | sudo apt-key add -
 sudo apt-get update -qq > /dev/null 2>&1
@@ -23,3 +25,6 @@ rosdep install -q --from-paths $CATKIN_WS_UNDERLAY_SRC -i -y --rosdistro $CI_ROS
 catkin_make -DCMAKE_BUILD_TYPE=Release
 # build install space of underlay
 catkin_make -DCMAKE_BUILD_TYPE=Release install > /dev/null 2>&1
+ret=$?
+kill %%
+echo $ret

--- a/.travis.script.sh
+++ b/.travis.script.sh
@@ -1,6 +1,8 @@
 set -e
 set -v
 
+while true; do echo "SCRIPT IS RUNNING" && sleep 5; done&
+
 # create empty overlay workspace
 mkdir -p $CATKIN_WS_SRC
 source $CATKIN_WS_UNDERLAY/install/setup.bash > /dev/null 2>&1 # source install space of underlay
@@ -16,3 +18,6 @@ source $CATKIN_WS/devel/setup.bash > /dev/null 2>&1 # source devel space of over
 catkin_make -DCMAKE_BUILD_TYPE=Release
 catkin_make run_tests # test overlay
 catkin_test_results --verbose
+ret=$?
+kill %%
+echo $ret


### PR DESCRIPTION
triggers regularly a console log output to prevent travis from stopping a long build without log