### PR TITLE
add catkin test arguments variable

### DIFF
--- a/.travis.script.sh
+++ b/.travis.script.sh
@@ -21,7 +21,7 @@ source $CATKIN_WS/install/setup.bash > /dev/null 2>&1 # source install space of 
 if [ "$CATKIN_ENABLE_TESTING" == "OFF" ]; then
   echo "Testing disabled"
 else
-  catkin_make run_tests # test overlay
+  catkin_make run_tests $CATKIN_TEST_ARGUMENTS # test overlay
 fi
 catkin_test_results --verbose
 ret=$?


### PR DESCRIPTION
if not specified: nothing should change
if specified: e.g. with "-j1" restricts testing to only one test at a time