### PR TITLE
add robot upstart as a dependency to the robot variant

### DIFF
--- a/care_o_bot_robot/package.xml
+++ b/care_o_bot_robot/package.xml
@@ -13,6 +13,7 @@
   <exec_depend>cob_bringup</exec_depend>
   <exec_depend>cob_manipulation</exec_depend>
   <exec_depend>cob_navigation</exec_depend>
+  <exec_depend>robot_upstart</exec_depend>
 
   <export>
     <metapackage/>


### PR DESCRIPTION
fixed issue raised in https://github.com/ipa320/setup_cob4/pull/30
